### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-vue-storefront-cloud.yml
+++ b/.github/workflows/deploy-vue-storefront-cloud.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: "16.x"
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.PROJECT_NAME }}-storefrontcloud-io/vue-storefront:${{ github.sha }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL || 'registry.vuestorefront.cloud' }}
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: "16.x"
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.PROJECT_NAME }}-storefrontcloud-io/vue-storefront-middleware:${{ github.sha }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL || 'registry.vuestorefront.cloud' }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore